### PR TITLE
Cleanup ordering a bit, create atomic commit of bulk data.

### DIFF
--- a/arcgis_scraper/arcgis_scraper.go
+++ b/arcgis_scraper/arcgis_scraper.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jinzhu/configor"
 
 	"github.com/gidoBOSSftw5731/log"
-	"github.com/lib/pq"
 	_ "github.com/lib/pq"
 )
 

--- a/arcgis_scraper/arcgis_scraper.go
+++ b/arcgis_scraper/arcgis_scraper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jinzhu/configor"
 
 	"github.com/gidoBOSSftw5731/log"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
 

--- a/arcgis_scraper/arcgis_scraper.go
+++ b/arcgis_scraper/arcgis_scraper.go
@@ -142,7 +142,7 @@ func loopingDownloader() {
 		log.Fatalf("failed to commit downloaded data: %v", err)
 	}
 
-	if err := txt.Commit(); err != nil {
+	if err := txn.Commit(); err != nil {
 		log.Fatalf("failed to commit and close the transaction: %v", err)
 	}
 

--- a/arcgis_scraper/arcgis_scraper.go
+++ b/arcgis_scraper/arcgis_scraper.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	db     = *sql.DB
+	db      *sql.DB
 	config = struct {
 		DB struct {
 			User     string `default:"covid19scraper"`


### PR DESCRIPTION
Cleanup some ordering of var/const/etc.
Create a single transaction for the bulk insert event.
This does two things:
  1) pay for statement creation 1x
  2) pay for indexing costs 1x
  3) make sure the data on the user facing portion is consistent
     (we haven't inserted half the data when the user requests content)